### PR TITLE
Adds support for fetching cached images from an HTTP(S) source

### DIFF
--- a/services/ImageFormats.js
+++ b/services/ImageFormats.js
@@ -49,7 +49,17 @@ module.exports = {
 
     if (cachedImage) {
       const url = uploadProvider.getPath(cachedImage);
-      const buffer = fs.readFileSync(url);
+      
+      let buffer = null;
+
+      # If the url is an HTTP url, get the image from the external source
+      if (url.indexOf('http://') >= 0 || url.indexOf('https://') >= 0) {
+        const image = await Jimp.read(url);
+        buffer = await image.getBufferAsync(Jimp.AUTO);
+      } else {
+        buffer = fs.readFileSync(url);
+      }
+
       return { mime: cachedImage.mime, buffer };
     }
 


### PR DESCRIPTION
Adds support for fetching cached images from an external source (like AWS S3) that provide the cached image via a url. The current implementation fails with a 500 error because the image is not located on the filesystem. `fs.readFile...` only supports fetching files located on the filesystem ([reference](https://stackoverflow.com/questions/48586522/readfilesync-from-an-url-for-twitter-media-node-js)).